### PR TITLE
pass corr method to cor.test

### DIFF
--- a/R/corrgram.r
+++ b/R/corrgram.r
@@ -373,7 +373,7 @@ panel.conf <- function(x, y, corr=NULL, col.regions, cor.method, digits=2, cex.c
     text(0.5, 0.6, est, cex=cex.cor)
 
   } else { # Calculate correlation and confidence interval
-    results <- cor.test(x, y, alternative = "two.sided")
+    results <- cor.test(x, y, alternative = "two.sided", method = cor.method)
 
     est <- results$estimate
     est <- formatC(est, digits=digits, format='f')


### PR DESCRIPTION
Kevin, in the `panel.conf` function, `cor.method` is not currently being passed `cor.test`. If you compare the following plots, the lower panel shading changes colors with different methods, but the rhos and confidence intervals do not. It looks like all the other panels are fine.

``` r
corrgram(iris, upper.panel = panel.conf, cor.method = 'pearson')
corrgram(iris, upper.panel = panel.conf, cor.method = 'spearman')
```
